### PR TITLE
purges via 'PURGE' HTTP method when FASTLY_API_KEY is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The Kiln project that is going to use this plugin should set the following envir
 FASTLY_API_KEY=cool-api-key
 ```
 
+If `FASTLY_API_KEY` is not provided, the plugin will fall back to making unauthenticated HTTP requests
+with the `PURGE` method. This is a good option if using IP origin rules for allowing purges.
+
 ## Getting Started
 
 1. Install the package as a dependency

--- a/src/utils/purge.js
+++ b/src/utils/purge.js
@@ -44,11 +44,9 @@ const purgeAuthenticated = function (url) {
  * @throws {Error} Throws an error if the request was not successful
  */
 const purge = function (url) {
-  return (
-    window.process.env.FASTLY_API_KEY
+  return window.process.env.FASTLY_API_KEY
     ? purgeAuthenticated(url)
-    : purgeUnauthenticated(url)
-  );
+    : purgeUnauthenticated(url);
 }
 
 module.exports = purge;

--- a/src/utils/purge.js
+++ b/src/utils/purge.js
@@ -3,12 +3,30 @@
 const { FASTLY_API_URL } = require('./constants');
 
 /**
- * Make a purge request to Fastly
+ * Make a purge request to Fastly via simple PURGE HTTP method.
  * @param {string} url
  * @returns {Promise<Object>} An object containing the request data
  * @throws {Error} Throws an error if the request was not successful
  */
-module.exports = url => {
+const purgeUnauthenticated = function (url) {
+  return fetch(url, { method: 'PURGE' })
+    .then(res => res.json())
+    .then(res => {
+      res.url = url;
+      return res;
+    })
+    .catch(e => {
+      throw e;
+    });
+};
+
+/**
+ * Make a purge request to Fastly via authenticated API.
+ * @param {string} url
+ * @returns {Promise<Object>} An object containing the request data
+ * @throws {Error} Throws an error if the request was not successful
+ */
+const purgeAuthenticated = function (url) {
   return fetch(`${FASTLY_API_URL}/${url}`, {
     method: 'POST',
     headers: {
@@ -24,3 +42,19 @@ module.exports = url => {
       throw e;
     });
 };
+
+/**
+ * Generic entrypoint for authenticated/unauthenticated purge reuqests.
+ * @param {string} url
+ * @returns {Promise<Object>} An object containing the request data
+ * @throws {Error} Throws an error if the request was not successful
+ */
+const purge = function (url) {
+  return (
+    window.process.env.FASTLY_API_KEY
+    ? purgeAuthenticated(url)
+    : purgeUnauthenticated(url)
+  );
+}
+
+module.exports = purge;

--- a/src/utils/purge.js
+++ b/src/utils/purge.js
@@ -14,9 +14,6 @@ const purgeUnauthenticated = function (url) {
     .then(res => {
       res.url = url;
       return res;
-    })
-    .catch(e => {
-      throw e;
     });
 };
 
@@ -37,9 +34,6 @@ const purgeAuthenticated = function (url) {
     .then(res => {
       res.url = url; // Attach the url to the response to use for messaging
       return res;
-    })
-    .catch(e => {
-      throw e;
     });
 };
 


### PR DESCRIPTION
Passing a `FASTLY_API_KEY` to the browser is not an especially secure
action. The ideal way to provide a purging service would be to hide the
Fastly calls behind an Amphora route (relying on the Amphora
authentication).

In lieu of that, if an IP origin list is used to secure PURGE requests,
we can skip the API key entirely. This situation would apply if editing
is restricted to users on an internal network or VPN.

This pull request will not modify existing behavior for anyone who currently expose a `FASTLY_API_KEY` to their Kiln plugin; those actions will continue using a `POST` to the Fastly API domain.